### PR TITLE
Fix author header and use default icon

### DIFF
--- a/_includes/author.html
+++ b/_includes/author.html
@@ -5,7 +5,7 @@
       {% if author.photo %}
         <img class="img-rounded" src="{{ author.photo }}" alt="{{ author.display_name }}">
       {% else %}
-        <img class="img-rounded" src="/assets/img/user.jpg" alt="{{ author.display_name }}">
+        <img class="img-rounded" src="/android-chrome-384x384.png" alt="{{ author.display_name }}">
       {% endif %}
       <p class="def">{{ site.translations.text.author | default: "Author" }}</p>
       <p class="name">
@@ -75,7 +75,7 @@
       {% if author.photo %}
       "image": "{{ author.photo }}",
       {% else %}
-      "image": {{ "/assets/img/user.jpg" | prepend: site.baseurl | prepend: site.url }},
+        "image": {{ "/android-chrome-384x384.png" | prepend: site.baseurl | prepend: site.url }},
       {% endif %}
       "jobTitle": "{{ author.position }}",
       "url": "{{ author.url | prepend: site.baseurl | prepend: site.url }}",

--- a/_layouts/author.html
+++ b/_layouts/author.html
@@ -6,10 +6,10 @@ layout: page
   {% if page.photo %}
     <img class="img-rounded" src="{{ page.photo }}" alt="{{ author.display_name }}">
   {% else %}
-    <img class="img-rounded" src="/assets/img/user.jpg" alt="{{ author.display_name }}">
+    <img class="img-rounded" src="/android-chrome-384x384.png" alt="{{ author.display_name }}">
   {% endif %}
 
-  <h1 class="name"> "auskaras.lt"</h1>
+  <h1 class="name">{{ page.display_name }}</h1>
 
   {% if page.position %}
     <h2 class="position">{{ page.position }}</h2>
@@ -57,7 +57,7 @@ layout: page
     {% if page.photo %}
     "image": "{{ page.photo }}",
     {% else %}
-    "image": {{ "/assets/img/user.jpg" | prepend: site.baseurl | prepend: site.url }},
+      "image": {{ "/android-chrome-384x384.png" | prepend: site.baseurl | prepend: site.url }},
     {% endif %}
     "jobTitle": "{{ page.position }}",
     "url": "{{ page.url | prepend: site.baseurl | prepend: site.url }}",

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -142,7 +142,7 @@
                 {% if author.photo %}
                 "image": "{{ author.photo }}",
                 {% else %}
-                "image": {{ "/assets/img/user.jpg" | prepend: site.baseurl | prepend: site.url }},
+                "image": {{ "/android-chrome-384x384.png" | prepend: site.baseurl | prepend: site.url }},
                 {% endif %}
                 "jobTitle": "{{ author.position }}",
                 "url": "{{ author.url | prepend: site.baseurl | prepend: site.url }}",


### PR DESCRIPTION
## Summary
- show author display name on author pages
- use the site's symbolic icon as the default author image

## Testing
- `bundle install`
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_6842a6cfad988321803530c828e7d46a