### PR TITLE
Fix author alt text

### DIFF
--- a/_includes/author.html
+++ b/_includes/author.html
@@ -2,10 +2,10 @@
 {% if author %}
   <section class="author">
     <div class="details">
-      {% if author.photo %}
+      {% if author.photo and author.photo != '/android-chrome-384x384.png' %}
         <img class="img-rounded" src="{{ author.photo }}" alt="{{ author.display_name }}">
       {% else %}
-        <img class="img-rounded" src="/assets/img/user.jpg" alt="{{ author.display_name }}">
+        <img class="img-rounded" src="/android-chrome-384x384.png" alt="Author icon">
       {% endif %}
       <p class="def">{{ site.translations.text.author | default: "Author" }}</p>
       <p class="name">
@@ -75,7 +75,7 @@
       {% if author.photo %}
       "image": "{{ author.photo }}",
       {% else %}
-      "image": {{ "/assets/img/user.jpg" | prepend: site.baseurl | prepend: site.url }},
+        "image": {{ "/android-chrome-384x384.png" | prepend: site.baseurl | prepend: site.url }},
       {% endif %}
       "jobTitle": "{{ author.position }}",
       "url": "{{ author.url | prepend: site.baseurl | prepend: site.url }}",

--- a/_layouts/author.html
+++ b/_layouts/author.html
@@ -3,13 +3,13 @@ layout: page
 ---
 
 <div class="staff">
-  {% if page.photo %}
-    <img class="img-rounded" src="{{ page.photo }}" alt="{{ author.display_name }}">
+  {% if page.photo and page.photo != '/android-chrome-384x384.png' %}
+    <img class="img-rounded" src="{{ page.photo }}" alt="{{ page.display_name }}">
   {% else %}
-    <img class="img-rounded" src="/assets/img/user.jpg" alt="{{ author.display_name }}">
+    <img class="img-rounded" src="/android-chrome-384x384.png" alt="Author icon">
   {% endif %}
 
-  <h1 class="name"> "auskaras.lt"</h1>
+  <h1 class="name">{{ page.display_name }}</h1>
 
   {% if page.position %}
     <h2 class="position">{{ page.position }}</h2>
@@ -57,7 +57,7 @@ layout: page
     {% if page.photo %}
     "image": "{{ page.photo }}",
     {% else %}
-    "image": {{ "/assets/img/user.jpg" | prepend: site.baseurl | prepend: site.url }},
+      "image": {{ "/android-chrome-384x384.png" | prepend: site.baseurl | prepend: site.url }},
     {% endif %}
     "jobTitle": "{{ page.position }}",
     "url": "{{ page.url | prepend: site.baseurl | prepend: site.url }}",

--- a/_layouts/post-2.html
+++ b/_layouts/post-2.html
@@ -467,7 +467,7 @@ February 21, 2024
   <section class="author">
     <div class="details">
 
-        <img class="img-rounded" src="/android-chrome-384x384.png" alt="auskaras.lt Author">
+        <img class="img-rounded" src="/android-chrome-384x384.png" alt="Author icon">
 
       <p class="def">Author</p>
       <p class="name">

--- a/_layouts/post-3.html
+++ b/_layouts/post-3.html
@@ -434,7 +434,7 @@ Having a lavish breakfast under the shade of mandarin trees is one of the immuta
   <section class="author">
     <div class="details">
 
-        <img class="img-rounded" src="/android-chrome-384x384.png" alt="auskaras.lt Author">
+        <img class="img-rounded" src="/android-chrome-384x384.png" alt="Author icon">
 
       <p class="def">Author</p>
       <p class="name">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -142,7 +142,7 @@
                 {% if author.photo %}
                 "image": "{{ author.photo }}",
                 {% else %}
-                "image": {{ "/assets/img/user.jpg" | prepend: site.baseurl | prepend: site.url }},
+                "image": {{ "/android-chrome-384x384.png" | prepend: site.baseurl | prepend: site.url }},
                 {% endif %}
                 "jobTitle": "{{ author.position }}",
                 "url": "{{ author.url | prepend: site.baseurl | prepend: site.url }}",


### PR DESCRIPTION
## Summary
- show a generic alt tag when using the default author icon
- keep author name alt only when a custom photo is used

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_6842a6cfad988321803530c828e7d46a